### PR TITLE
Introduce higher-order context management for state and action spaces

### DIFF
--- a/decuen/agents/_agent.py
+++ b/decuen/agents/_agent.py
@@ -13,6 +13,7 @@ from decuen.memories._memory import Memory, Transition
 from decuen.strategies._strategy import Strategy
 from decuen.strategies.rand import RandomStrategy
 from decuen.utils import checks
+from decuen.utils.context import get_context
 
 
 @dataclass
@@ -43,11 +44,10 @@ class Agent(ABC):
     # Current agent trajectory
     _trajectory: List[Transition]
 
-    def __init__(self, state_space: Space, action_space: Space, memory: Memory,
-                 settings: AgentSettings = AgentSettings()) -> None:
+    def __init__(self, memory: Memory, settings: AgentSettings = AgentSettings()) -> None:
         """Initialize a generic agent."""
-        self.state_space = state_space
-        self.action_space = action_space
+        self.state_space = get_context().state_space
+        self.action_space = get_context().action_space
         self.memory = memory
         self.settings = settings
 
@@ -118,11 +118,9 @@ class ActorAgent(Agent):
 
     actor: Actor
 
-    # pylint: disable=too-many-arguments
-    def __init__(self, state_space: Space, action_space: Space, memory: Memory, actor: Actor,
-                 settings: AgentSettings = AgentSettings()) -> None:
+    def __init__(self, memory: Memory, actor: Actor, settings: AgentSettings = AgentSettings()) -> None:
         """Initialize a generic actor agent."""
-        super().__init__(state_space, action_space, memory, settings)
+        super().__init__(memory, settings)
         self.actor = actor
 
     def act(self, state: np.ndarray) -> np.ndarray:
@@ -163,12 +161,10 @@ class CriticAgent(Agent):
     strategy: Strategy
 
     # TODO: support state critic and action critic
-    # pylint: disable=too-many-arguments
-    def __init__(self, state_space: Space, action_space: Space,
-                 memory: Memory, critic: ActionCritic, strategy: Strategy,
+    def __init__(self, memory: Memory, critic: ActionCritic, strategy: Strategy,
                  settings: AgentSettings = AgentSettings()) -> None:
         """Initialize a generic critic agent."""
-        super().__init__(state_space, action_space, memory, settings)
+        super().__init__(memory, settings)
         self.critic = critic
         self.strategy = strategy
 
@@ -212,14 +208,12 @@ class ActorCriticAgent(ActorAgent, CriticAgent):
     actor-critic framework from scratch as would be the case using a regular agent.
     """
 
-    # pylint: disable=too-many-arguments
-    def __init__(self, state_space: Space, action_space: Space,
-                 memory: Memory, actor: Actor, critic: ActionCritic,
+    def __init__(self, memory: Memory, actor: Actor, critic: ActionCritic,
                  settings: AgentSettings = AgentSettings()) -> None:
         """Initialize a generic actor-critic agent."""
-        ActorAgent.__init__(self, state_space, action_space, memory, actor, settings)
+        ActorAgent.__init__(self, memory, actor, settings)
         # Note that strategy does nothing in this case since we are never calling the `act` of the `CriticAgent`
-        CriticAgent.__init__(self, state_space, action_space, memory, critic, RandomStrategy(), settings)
+        CriticAgent.__init__(self, memory, critic, RandomStrategy(), settings)
         self.actor = actor
         self.critic = critic
 

--- a/decuen/agents/dqn.py
+++ b/decuen/agents/dqn.py
@@ -23,11 +23,10 @@ class DQNAgent(CriticAgent):
     critic: _DQNCritic
 
     # pylint: disable=too-many-arguments
-    def __init__(self, state_space: Discrete, action_space: Discrete,
-                 memory: Memory, critic: _DQNCritic, strategy: Strategy,
+    def __init__(self, memory: Memory, critic: _DQNCritic, strategy: Strategy,
                  settings: DQNAgentSettings = DQNAgentSettings()) -> None:
         """Initialize a deep Q-network critic agent."""
-        super().__init__(state_space, action_space, memory, critic, strategy, settings)
+        super().__init__(memory, critic, strategy, settings)
 
     def act(self, state: np.ndarray) -> np.ndarray:
         """Generate an action to perform based on the Q-values of different actions in a state."""

--- a/decuen/agents/dqn.py
+++ b/decuen/agents/dqn.py
@@ -4,7 +4,6 @@
 from dataclasses import dataclass
 
 import numpy as np  # type: ignore
-from gym.spaces import Discrete  # type: ignore
 
 from decuen.agents._agent import AgentSettings, CriticAgent
 from decuen.critics.dqn import _DQNCritic

--- a/decuen/agents/qtable.py
+++ b/decuen/agents/qtable.py
@@ -3,7 +3,6 @@
 from dataclasses import dataclass
 
 import numpy as np  # type: ignore
-from gym.spaces import Discrete  # type: ignore
 
 from decuen.agents._agent import AgentSettings, CriticAgent
 from decuen.critics.qtable import QTableCritic, QTableCriticSettings

--- a/decuen/agents/qtable.py
+++ b/decuen/agents/qtable.py
@@ -22,11 +22,11 @@ class QTableAgent(CriticAgent):
     critic: QTableCritic
 
     # pylint: disable=too-many-arguments
-    def __init__(self, state_space: Discrete, action_space: Discrete, memory: Memory, strategy: Strategy,
+    def __init__(self, memory: Memory, strategy: Strategy,
                  settings: QTableAgentSettings = QTableAgentSettings()) -> None:
         """Initialize a Q-table critic agent."""
-        critic = QTableCritic(state_space, action_space, settings)
-        super().__init__(state_space, action_space, memory, critic, strategy, settings)
+        critic = QTableCritic(settings)
+        super().__init__(memory, critic, strategy, settings)
 
     def act(self, state: np.ndarray) -> np.ndarray:
         """Generate an action to perform based on the Q-values of different actions in a state."""

--- a/decuen/critics/_critic.py
+++ b/decuen/critics/_critic.py
@@ -8,6 +8,7 @@ import numpy as np  # type: ignore
 from gym import Space  # type: ignore
 
 from decuen.memories._memory import Transition
+from decuen.utils.context import get_context
 
 
 @dataclass
@@ -45,11 +46,10 @@ class Critic(ABC):
     settings: CriticSettings
     _learn_step: int
 
-    def __init__(self, state_space: Space, action_space: Space,
-                 settings: CriticSettings = CriticSettings()) -> None:
+    def __init__(self, settings: CriticSettings = CriticSettings()) -> None:
         """Initialize this generic critic interface."""
-        self.state_space = state_space
-        self.action_space = action_space
+        self.state_space = get_context().state_space
+        self.action_space = get_context().action_space
         self.settings = settings
         self._learn_step = 0
 
@@ -70,10 +70,9 @@ class StateCritic(Critic):
 
     settings: StateCriticSettings
 
-    def __init__(self, state_space: Space, action_space: Space,
-                 settings: StateCriticSettings = StateCriticSettings()) -> None:
+    def __init__(self, settings: StateCriticSettings = StateCriticSettings()) -> None:
         """Initialize this generic state critic interface."""
-        super().__init__(state_space, action_space, settings)
+        super().__init__(settings)
 
     @abstractmethod
     def crit(self, state: np.ndarray) -> float:
@@ -91,10 +90,9 @@ class ActionCritic(Critic):
 
     settings: ActionCriticSettings
 
-    def __init__(self, state_space: Space, action_space: Space,
-                 settings: ActionCriticSettings = ActionCriticSettings()) -> None:
+    def __init__(self, settings: ActionCriticSettings = ActionCriticSettings()) -> None:
         """Initialize this generic actor critic interface."""
-        super().__init__(state_space, action_space, settings)
+        super().__init__(settings)
 
     @abstractmethod
     def crit(self, state: np.ndarray, action: np.ndarray) -> float:

--- a/decuen/critics/dqn.py
+++ b/decuen/critics/dqn.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import MutableSequence
 
 import numpy as np  # type: ignore
-from gym.spaces import Discrete, Space  # type: ignore
+from gym.spaces import Discrete  # type: ignore
 from tensorflow.keras import Sequential  # type: ignore
 from tensorflow.keras.models import clone_model  # type: ignore
 
@@ -34,17 +34,17 @@ class DQNCriticSettings(ActionCriticSettings):
 class _DQNCritic(ActionCritic):
     """Abstract DQN agent for common functionalities between DQN and DDQN."""
 
+    action_space: Discrete
     settings: DQNCriticSettings
     network: Sequential
     _target_network: Sequential
 
-    def __init__(self, state_space: Space, action_space: Discrete, model: Sequential,
-                 settings: DQNCriticSettings = DQNCriticSettings()) -> None:
+    def __init__(self, model: Sequential, settings: DQNCriticSettings = DQNCriticSettings()) -> None:
         """Initialize this generic actor critic interface."""
-        super().__init__(state_space, action_space, settings)
+        super().__init__(settings)
 
         # TODO: possibly generalize to multi-discrete spaces
-        if not isinstance(action_space, Discrete):
+        if not isinstance(self.action_space, Discrete):
             raise TypeError("action space for Q-table critic must be discrete")
 
         self.network = model

--- a/decuen/critics/qtable.py
+++ b/decuen/critics/qtable.py
@@ -31,22 +31,23 @@ class QTableCriticSettings(ActionCriticSettings):
 class QTableCritic(ActionCritic):
     """Q-table critic based on [1]."""
 
+    state_space: Discrete
+    action_space: Discrete
     settings: QTableCriticSettings
     table: np.ndarray
 
-    def __init__(self, state_space: Discrete, action_space: Discrete,
-                 settings: QTableCriticSettings = QTableCriticSettings()) -> None:
+    def __init__(self, settings: QTableCriticSettings = QTableCriticSettings()) -> None:
         """Initialize this generic actor critic interface."""
-        super().__init__(state_space, action_space, settings)
+        super().__init__(settings)
 
-        # TODO: possibly generalize to multi-discrete spaces
-        if not isinstance(state_space, Discrete):
+        # # TODO: possibly generalize to multi-discrete spaces
+        if not isinstance(self.state_space, Discrete):
             raise TypeError("state space for Q-table critic must be discrete")
-        if not isinstance(action_space, Discrete):
+        if not isinstance(self.action_space, Discrete):
             raise TypeError("action space for Q-table critic must be discrete")
 
         # XXX: possibly experiment with different initialization techniques
-        self.table = np.zeros((state_space.n, action_space.n))
+        self.table = np.zeros((self.state_space.n, self.action_space.n))
 
     def learn(self, transitions: MutableSequence[Transition]) -> None:
         """Update internal critic representation based on past transitions.

--- a/decuen/utils/context.py
+++ b/decuen/utils/context.py
@@ -1,0 +1,144 @@
+"""Utilities for managing environmental context."""
+
+import functools
+from typing import Callable, ClassVar, List, Optional, TypeVar, Union, cast
+
+from gym import Env, Space  # type: ignore
+
+
+class EnvironmentalContext:
+    """Context manager for environmental spaces.
+
+    Use this to create custom contexts that can subsequently either be used as a context manager to enclose a scope in
+    context, or be passed into the universal context for use as the default context. This context is then used by the
+    `with_context` function wrapper to inject state and action space environmental context into function that need it.
+
+    For example, we can create a scope-encapsulated context by using an instance of this class as a context manager:
+    >>> with EnvironmentalContext(state_space=..., action_space=...) as ctx:
+    >>>     ...
+    Notice that if either <state_space> or <action_space> is unspecified in the initialization, this context manager
+    is considered partial. Functions requiring context will still require the unspecified spaces or else an error will
+    be raised.
+
+    We can also directly set an environmental context to be the universal context:
+    >>> CTX.set_context(EnvironmentalContext(state_space=..., action_space=...))
+    """
+
+    _state_space: Optional[Space]
+    _action_space: Optional[Space]
+    _prev_contexts: List['EnvironmentalContext']
+
+    def __init__(self, *, state_space: Optional[Space] = None, action_space: Optional[Space] = None) -> None:
+        """Initialize an envionmental context with optional state and action spaces."""
+        self._state_space = state_space
+        self._action_space = action_space
+        self._prev_contexts = []
+
+    @property
+    def state_space(self) -> Space:
+        """Access the state space associated with this environmental context."""
+        if self._state_space is None:
+            return ValueError("no state space in context")
+        return self._state_space
+
+    @state_space.setter
+    def state_space(self, space: Space) -> None:
+        self._state_space = space
+
+    @property
+    def action_space(self) -> Space:
+        """Access the action space associated with this environmental context."""
+        if self._action_space is None:
+            return ValueError("no action space in context")
+        return self._action_space
+
+    @action_space.setter
+    def action_space(self, space: Space) -> None:
+        self._action_space = space
+
+    def __enter__(self):
+        """Use this environmental context as a context manager."""
+        self._prev_contexts.append(CTX.get_context())
+        CTX.set_context(self)
+
+    def __exit__(self, *args):
+        """Exit this environmental context manager and restore the previous context."""
+        CTX.set_context(self._prev_contexts.pop())
+
+
+class UniversalContext:
+    """Singleton encapsulating the universal environmental context.
+
+    Simply provides an interface to get and set the current context. Note that this management is not thread-safe.
+    """
+
+    _context: ClassVar[EnvironmentalContext] = EnvironmentalContext()
+
+    @classmethod
+    def get_context(cls) -> EnvironmentalContext:
+        """Get the current environmental context."""
+        return cls._context
+
+    @classmethod
+    def set_context(cls, context: EnvironmentalContext) -> None:
+        """Set the current environmental context."""
+        cls._context = context
+
+
+CTX = UniversalContext
+
+
+def get_context() -> EnvironmentalContext:
+    """Get the current universal context."""
+    return CTX.get_context()
+
+
+def set_context(context: Union[EnvironmentalContext, Env]) -> None:
+    """Set the current universal context.
+
+    Can set based on an `EnvironmentalContext` object or an OpenAI Gym `Env` object.
+    """
+    if isinstance(context, Env):
+        context = EnvironmentalContext(state_space=context.observation_space, action_space=context.action_space)
+    CTX.set_context(context)
+
+
+FuncType = TypeVar("FuncType", bound=Callable)
+
+
+def with_context(func: FuncType) -> FuncType:
+    """Inject the current environmental context into this function.
+
+    This function was constructed to be used as a decorator to initialization functions that expect the state and action
+    space of the environment they are working in. Using this functions requires the last two arguments of the wrapped
+    function to respectively be `state_space` and `action_space` and they must be keyword-only arguments.
+
+    Using this function injects the current envrionmental context into the function by way of those keyword arguments.
+    For this function to have any effect, the current context must be populated which can be done by ways of the
+    universal singleton context `UniversalContext` aliased by `CTX` or by directly using an `EnvironmentalContext`
+    context manager to associate a context with a scope.
+    """
+    state_space_kwarg_name = "state_space"
+    action_space_kwarg_name = "action_space"
+
+    num_kwargs = func.__code__.co_kwonlyargcount
+    kwarg_names = func.__code__.co_varnames
+
+    if num_kwargs < 2:
+        raise ValueError(
+            "wrapper {with_context.__name__} requires function to accept at least two keyword-only arguments")
+    if kwarg_names[-2] != state_space_kwarg_name:
+        raise ValueError(
+            "wrapper {with_context.__name__} requires second-last argument to be named '{state_space_kwarg_name}'")
+    if kwarg_names[-1] != action_space_kwarg_name:
+        raise ValueError(
+            "wrapper {with_context.__name__} requires last argument to be named '{action_space_kwarg_name}'")
+
+    @functools.wraps(func)
+    def context_wrapper(*args, **kwargs):
+        if state_space_kwarg_name not in kwargs:
+            kwargs[state_space_kwarg_name] = CTX.get_context().state_space
+        if action_space_kwarg_name not in kwargs:
+            kwargs[action_space_kwarg_name] = CTX.get_context().action_space
+        func(*args, **kwargs)
+    return cast(FuncType, context_wrapper)


### PR DESCRIPTION
By injecting the environmental context into the initialization of objects that require environmental constructs such as state and action spaces, we reduce the need to pass these variables all around the framework.

Also implements some helper objects and functions to keep the degree of flexibility we had before.