### PR TITLE
Remove default settings values

### DIFF
--- a/decuen/agents/_agent.py
+++ b/decuen/agents/_agent.py
@@ -44,7 +44,7 @@ class Agent(ABC):
     # Current agent trajectory
     _trajectory: List[Transition]
 
-    def __init__(self, memory: Memory, settings: AgentSettings = AgentSettings()) -> None:
+    def __init__(self, memory: Memory, settings: AgentSettings) -> None:
         """Initialize a generic agent."""
         self.state_space = get_context().state_space
         self.action_space = get_context().action_space
@@ -118,7 +118,7 @@ class ActorAgent(Agent):
 
     actor: Actor
 
-    def __init__(self, memory: Memory, actor: Actor, settings: AgentSettings = AgentSettings()) -> None:
+    def __init__(self, memory: Memory, actor: Actor, settings: AgentSettings) -> None:
         """Initialize a generic actor agent."""
         super().__init__(memory, settings)
         self.actor = actor
@@ -161,8 +161,7 @@ class CriticAgent(Agent):
     strategy: Strategy
 
     # TODO: support state critic and action critic
-    def __init__(self, memory: Memory, critic: ActionCritic, strategy: Strategy,
-                 settings: AgentSettings = AgentSettings()) -> None:
+    def __init__(self, memory: Memory, critic: ActionCritic, strategy: Strategy, settings: AgentSettings) -> None:
         """Initialize a generic critic agent."""
         super().__init__(memory, settings)
         self.critic = critic
@@ -208,8 +207,7 @@ class ActorCriticAgent(ActorAgent, CriticAgent):
     actor-critic framework from scratch as would be the case using a regular agent.
     """
 
-    def __init__(self, memory: Memory, actor: Actor, critic: ActionCritic,
-                 settings: AgentSettings = AgentSettings()) -> None:
+    def __init__(self, memory: Memory, actor: Actor, critic: ActionCritic, settings: AgentSettings) -> None:
         """Initialize a generic actor-critic agent."""
         ActorAgent.__init__(self, memory, actor, settings)
         # Note that strategy does nothing in this case since we are never calling the `act` of the `CriticAgent`

--- a/decuen/agents/q.py
+++ b/decuen/agents/q.py
@@ -21,8 +21,7 @@ class QAgent(CriticAgent):
     critic: QCritic
 
     # pylint: disable=too-many-arguments
-    def __init__(self, memory: Memory, critic: QCritic, strategy: Strategy,
-                 settings: QAgentSettings = QAgentSettings()) -> None:
+    def __init__(self, memory: Memory, critic: QCritic, strategy: Strategy, settings: QAgentSettings) -> None:
         """Initialize a Q-value based critic agent."""
         super().__init__(memory, critic, strategy, settings)
 

--- a/decuen/critics/_critic.py
+++ b/decuen/critics/_critic.py
@@ -46,7 +46,7 @@ class Critic(ABC):
     settings: CriticSettings
     _learn_step: int
 
-    def __init__(self, settings: CriticSettings = CriticSettings()) -> None:
+    def __init__(self, settings: CriticSettings) -> None:
         """Initialize this generic critic interface."""
         self.state_space = get_context().state_space
         self.action_space = get_context().action_space
@@ -70,7 +70,7 @@ class StateCritic(Critic):
 
     settings: StateCriticSettings
 
-    def __init__(self, settings: StateCriticSettings = StateCriticSettings()) -> None:
+    def __init__(self, settings: StateCriticSettings) -> None:
         """Initialize this generic state critic interface."""
         super().__init__(settings)
 
@@ -90,7 +90,7 @@ class ActionCritic(Critic):
 
     settings: ActionCriticSettings
 
-    def __init__(self, settings: ActionCriticSettings = ActionCriticSettings()) -> None:
+    def __init__(self, settings: ActionCriticSettings) -> None:
         """Initialize this generic actor critic interface."""
         super().__init__(settings)
 

--- a/decuen/critics/_critic.py
+++ b/decuen/critics/_critic.py
@@ -15,7 +15,7 @@ from decuen.utils.context import get_context
 class CriticSettings:
     """Basic common settings for all critics."""
 
-    discount_factor: float = 0.99
+    discount_factor: float
 
 
 @dataclass

--- a/decuen/critics/_q.py
+++ b/decuen/critics/_q.py
@@ -17,8 +17,8 @@ from decuen.memories._memory import Transition
 class QCriticSettings(ActionCriticSettings):
     """Q-value based critic settings."""
 
-    target_update: int = 1
-    double: bool = False
+    target_update: int
+    double: bool
 
 
 class QCritic(ActionCritic):

--- a/decuen/critics/_q.py
+++ b/decuen/critics/_q.py
@@ -24,7 +24,7 @@ class QCriticSettings(ActionCriticSettings):
 class QCritic(ActionCritic):
     """Abstract Q-value based critic to be used for building implementations of Q-value based critics."""
 
-    def __init__(self, settings: QCriticSettings = QCriticSettings()) -> None:
+    def __init__(self, settings: QCriticSettings) -> None:
         """Initialize an abstract Q-value based critic."""
         super().__init__(settings)
 

--- a/decuen/critics/dqn.py
+++ b/decuen/critics/dqn.py
@@ -10,7 +10,6 @@ Implements both deep Q-learning [1, 2] and double deep Q-learning [3] algorithms
     https://arxiv.org/pdf/1509.06461.pdf
 """
 
-from abc import abstractmethod
 from dataclasses import dataclass
 from typing import MutableSequence
 
@@ -40,7 +39,7 @@ class DQNCritic(QCritic):
     network: Sequential
     _target_network: Sequential
 
-    def __init__(self, model: Sequential, settings: DQNCriticSettings = DQNCriticSettings()) -> None:
+    def __init__(self, model: Sequential, settings: DQNCriticSettings) -> None:
         """Initialize this generic actor critic interface."""
         super().__init__(settings)
 

--- a/decuen/critics/qtable.py
+++ b/decuen/critics/qtable.py
@@ -25,7 +25,7 @@ from decuen.utils import checks
 class QTableCriticSettings(QCriticSettings):
     """Settings for Q-table critics."""
 
-    learning_rate: float = 0.01
+    learning_rate: float
 
 
 class QTableCritic(QCritic):

--- a/decuen/critics/qtable.py
+++ b/decuen/critics/qtable.py
@@ -36,7 +36,7 @@ class QTableCritic(QCritic):
     settings: QTableCriticSettings
     table: np.ndarray
 
-    def __init__(self, settings: QTableCriticSettings = QTableCriticSettings()) -> None:
+    def __init__(self, settings: QTableCriticSettings) -> None:
         """Initialize this generic actor critic interface."""
         super().__init__(settings)
 


### PR DESCRIPTION
Encourages the framework to be slightly more transparent, once we introduce examples people can use premade settings for the more complex modules.

Depends on #15 